### PR TITLE
possible fix for non-functional backspace key

### DIFF
--- a/engine.c
+++ b/engine.c
@@ -1046,6 +1046,7 @@ cmd_keyboard(int ch)
 	case KEY_BACKSPACE:
 	case KEY_DC:
 	case CTRL_H:
+	case 0x7f:
 		if (cmd_len > 0) {
 			cmdbuf[--cmd_len] = 0;
 		} else


### PR DESCRIPTION
this fixes the <kbd>BACKSPACE</kbd> key not working for me in pfSense / pfTop