### PR TITLE
Fix memory leak in read_states() by freeing pfctl_get_states() tail queue

### DIFF
--- a/pftop.c
+++ b/pftop.c
@@ -730,6 +730,12 @@ read_states(void)
 		cache_endupdate();
 	}
 
+	while (!TAILQ_EMPTY(&ps.states)) {
+		i = TAILQ_FIRST(&ps.states);
+		TAILQ_REMOVE(&ps.states, i, entry);
+		free(i);
+	}
+
 	num_disp = num_states;
 	return 0;
 }

--- a/pftop.c
+++ b/pftop.c
@@ -730,11 +730,7 @@ read_states(void)
 		cache_endupdate();
 	}
 
-	while (!TAILQ_EMPTY(&ps.states)) {
-		i = TAILQ_FIRST(&ps.states);
-		TAILQ_REMOVE(&ps.states, i, entry);
-		free(i);
-	}
+	pfctl_free_states(&ps);
 
 	num_disp = num_states;
 	return 0;


### PR DESCRIPTION
read_states() in pftop.c calls pfctl_get_states() in libpfctl. That allocates a tail queue (i.e., space for the state entries plus the overhead for the tail queue itself) and returns that. Then read_states() runs over that and copies the data into its own structures but it never cleans up the tail queue.

This commit adds code to free the tail queue after copying the data.

Reported-by: Harold Gutch